### PR TITLE
【Fixed】'rails g'コマンドの際にいらないファイルが生成されないように改善

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -9,20 +9,6 @@ Bundler.require(*Rails.groups)
 module ShareApp
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 6.1
-
-    # Configuration for the application, engines, and railties goes here.
-    #
-    # These settings can be overridden in specific environments using the files
-    # in config/environments, which are processed later.
-    #
-    # config.time_zone = "Central Time (US & Canada)"
-    # config.eager_load_paths << Rails.root.join("extras")
-  end
-end
-
-module DiveIntoWork
-  class Application < Rails::Application
     config.time_zone = 'Tokyo'
     config.active_record.default_timezone = :local
 
@@ -34,9 +20,12 @@ module DiveIntoWork
       # この二行の記述で自動生成しない設定を作成しています。
       g.assets false
       g.helper false
-    end
-    # Settings in config/environments/* take precedence over those specified here.
-    # Application configuration should go into files in config/initializers
-    # -- all .rb files in that directory are automatically loaded.
+    # Configuration for the application, engines, and railties goes here.
+    #
+    # These settings can be overridden in specific environments using the files
+    # in config/environments, which are processed later.
+    #
+    # config.time_zone = "Central Time (US & Canada)"
+    # config.eager_load_paths << Rails.root.join("extras")
   end
 end


### PR DESCRIPTION
#1 

config/application.rb に対してg.assets  false  g.helper falseオプションを追記
